### PR TITLE
Add `users#show` - a list of the top ratings by a given user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'backbone-on-rails'
 #Recommendation algorithm
 gem 'slope_one'
 
+gem 'puma'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    puma (2.11.1)
+      rack (>= 1.1, < 2.0)
     rack (1.6.0)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -196,6 +198,7 @@ DEPENDENCIES
   newrelic_rpm
   pg
   pry
+  puma
   rails (= 4.2.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ If you want to contribute to this project, I will bless your soul. Or if you don
 5.  Lists
 6.  Add group id to tags, (e.g. group 1 to completion status, group 2 to genre) to help organize tag display
 7.  Work delete functionality
-8.  User pages, with information on the works they've rated and ratings they've given, and ability to recommend users to other users (based on similarity of ratings), and then also to follow the user
+8.  User pages need the ability to recommend users to other users (based on similarity of ratings), and then also to follow the user
 9.  When a user updates or creates a rating on the work show page, the rating bars and rating numbers get updated (not just averages and counts)

--- a/app/assets/stylesheets/ratings.scss
+++ b/app/assets/stylesheets/ratings.scss
@@ -14,6 +14,10 @@
   color: blue;
   margin-right:0px;
   margin-top:-1px;
+
+  &.stars-wide {
+    width: 200px;
+  }
 }
 
 .avg-rating {

--- a/app/assets/stylesheets/read.scss
+++ b/app/assets/stylesheets/read.scss
@@ -25,7 +25,7 @@ table {
   padding-bottom: 30px;
 }
 
-#read-works td p{
+#read-works td p,a {
   margin: 0px;
   margin-top: 9px;
   margin-bottom: 9px;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -26,3 +26,18 @@ input.button {
   border-color: #808080 !important;
   float: left;
 }
+
+#user-ratings {
+  .tag-display-box {
+    clear: both;
+    padding-top: 7px;
+  }
+  p.description {
+    margin-top: 8px;
+    white-space: pre-wrap;
+    color: black;
+  }
+  p.link-text {
+    color: black;
+  }
+}

--- a/app/assets/templates/comments/comment_show.jst.ejs
+++ b/app/assets/templates/comments/comment_show.jst.ejs
@@ -1,6 +1,9 @@
 <div class="single-comment depth<%=comment.get("depth") %>" id="<%= comment.escape("id") %>">
   <div class="comment-data">
-    <p class="username"><%= comment.escape("username") %></p>
+    <a class="username" href="/users/<%= comment.get("user_id") %>">
+      <%= comment.escape("username") %>
+    </a>
+
     <div class="raty user-rating"></div>
     <p class="time-ago"><%= comment.escape("time_ago") %> ago</p>
   </div>

--- a/app/assets/templates/leaderboard.jst.ejs
+++ b/app/assets/templates/leaderboard.jst.ejs
@@ -25,7 +25,7 @@
         </p>
       </td>
       <td>
-        <p class="username">
+        <a class="username" href="/users/<%= user.get("2") %>">
           <%= user.escape("0") %>
         </p>
       </td>

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,8 @@
 class UsersController < ApplicationController
+  def show
+    @user = User.find params[:id]
+    @ratings = @user.ratings.includes(:work => :tags).order("rating desc").limit(200).all
+  end
 
   def new
   end
@@ -22,8 +26,7 @@ class UsersController < ApplicationController
 
   private
 
-    def user_params
-      params.require(:user).permit(:email, :username, :password)
-    end
-
+  def user_params
+    params.require(:user).permit(:email, :username, :password)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,10 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.where("points > 0").order("points DESC").pluck(:username, :points, :id)
+    @users = User.where("points > 0").
+      order("points DESC").
+      limit(200).
+      pluck(:username, :points, :id)
     render json: @users
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.where("points > 0").order("points DESC").pluck(:username, :points)
+    @users = User.where("points > 0").order("points DESC").pluck(:username, :points, :id)
     render json: @users
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -126,6 +126,10 @@ class Work < ActiveRecord::Base
     self.fives = counts[5]
   end
 
+  def ratings_count
+    ones + twos + threes + fours + fives
+  end
+
   def calculate_average_rating
     ratings = self.ratings
 

--- a/app/views/comments/_show.json.jbuilder
+++ b/app/views/comments/_show.json.jbuilder
@@ -16,6 +16,7 @@ end
 
 json.id comment.id
 json.username user.username
+json.user_id user.id
 
 if (comment.parent_comment_id)
   json.parent_comment_id comment.parent_comment_id

--- a/app/views/users/_rating.html.erb
+++ b/app/views/users/_rating.html.erb
@@ -1,0 +1,45 @@
+<div class="work index-display">
+  <div class="inner-work">
+    <div class="title-and-author">
+      <p class="title">
+        <a href="/#/works/<%= rating.work_id %>"><%= rating.work.name %></a>
+      </p>
+      <p class="author"> by <%= rating.work.author %></p>
+    </div>
+
+    <div class="stats">
+      <div class="stars stars-wide">
+        <%= user.username %>'s rating:
+        <span class="avg"><%= rating.rating.to_f.round(1) %></span>
+        <br>
+        <%= render partial: "stars", locals: { rating: rating.rating } %>
+      </div>
+
+      <div class="stars stars-wide">
+        Average rating:
+        <span class="avg"><%= rating.work.bayesian_average.round(2) %></span>
+        <br>
+        <%= render partial: "stars", locals: { rating: rating.work.bayesian_average.round } %>
+      </div>
+
+      <div class="date" title="Date added to site">
+        <%= rating.work.created_at.strftime("%B %d, %Y") %>
+      </div>
+
+      <div class="length" title="Short works have less than 25k words, medium works less than 100k, and long works less than 500k. Epic works, are well, epic.">
+        <%= rating.work.length %>
+      </div>
+
+      <div class="tag-display-box">
+        <% rating.work.tags.each do |tag| %>
+          <div class="single-tag"><p><%= tag.name %></p></div>
+        <% end %>
+      </div>
+
+      <p class="description"><%= rating.work.description %></p>
+      <p class="link-text">
+        Learn more
+        <a class="link-link" href="/#/works/<%= rating.work_id %>">here</a>.
+    </div>
+  </div>
+</div>

--- a/app/views/users/_stars.html.erb
+++ b/app/views/users/_stars.html.erb
@@ -1,0 +1,8 @@
+<div class="raty user-rating">
+  <% rating.times do |n| %>
+    <img src="https://s3.amazonaws.com/rationalreads/star-on.png" alt="<%= n.to_s %>">
+  <% end %>
+  <% (5 - rating).times do |n| %>
+    <img src="https://s3.amazonaws.com/rationalreads/star-off.png" alt="<%= n.to_s %>">
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,10 @@
+<div id="user-ratings">
+  <h1><%= @user.username %>'s Ratings</h1>
+
+  <div id="ratings-list">
+    <% @ratings.each_with_index do |r, n| %>
+      <% if n != 0 %><hr><% end %>
+      <%= render partial: "rating", locals: { user: @user, rating: r } %>
+    <% end %>
+  </div>
+</div>

--- a/db/migrate/20150329224433_add_rating_to_ratings_index.rb
+++ b/db/migrate/20150329224433_add_rating_to_ratings_index.rb
@@ -1,0 +1,6 @@
+class AddRatingToRatingsIndex < ActiveRecord::Migration
+  def change
+    add_index :ratings, [:user_id, :rating], name: "index_ratings_by_user"
+    remove_index :ratings, name: "index_ratings_on_user_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150328211041) do
+ActiveRecord::Schema.define(version: 20150329224433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 20150328211041) do
     t.integer  "chapter_id"
   end
 
-  add_index "ratings", ["user_id"], name: "index_ratings_on_user_id", using: :btree
+  add_index "ratings", ["user_id", "rating"], name: "index_ratings_by_user", using: :btree
   add_index "ratings", ["work_id"], name: "index_ratings_on_work_id", using: :btree
 
   create_table "taggings", force: :cascade do |t|


### PR DESCRIPTION
This PR actually includes a couple of other details:

3a8aa adds the `puma` gem to the Gemfile, which will cause heroku (and devs) to run under that instead of Webrick, for a probably enormous performance improvement (x4 locally, but possibly more on heroku).

4c40b Adds a limit to the leaderboard's size - it's not an issue at the current scale, but when you cross a few thousand users it'll start to become a problem rendering that much onto the screen. I'll revert this if you'd prefer - I think a paging solution is probably a better answer anyway.

Aside from those asides, I added an endpoint at `/users/:id` which essentially just displays a list of the user's ratings in descending order - the work in question is displayed with some detail, since discovery is the goal here. I cribbed the bulk of the styling from other sections of the application (reused where possible). The leaderboard and displayed individual comments both now use the username as a link to that page (styling unchanged).
